### PR TITLE
Fixed slow Parquet metadata reader

### DIFF
--- a/virtual/v_compressor.py
+++ b/virtual/v_compressor.py
@@ -37,6 +37,7 @@ def _compress_impl(con, fn, data: pd.DataFrame | pathlib.Path, schema, target_co
   # Flush from duckdb.
   con.execute(fn(con, schema, target_columns, tmp_path))
 
+  # No Arrow to apply?
   if not apply_arrow:
     return {
       'tmp_path' : tmp_path,

--- a/virtual/v_size.py
+++ b/virtual/v_size.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 PARQUET_COMPRESSION_TYPE = 'snappy'
 
+# TODO: At compression time, we should also put the schema and functions to avoid the slow table rewrite at the end.
 def arrow_compress_parquet(in_file, out_file):
   table = pq.read_table(in_file)
   pq.write_table(table, out_file, compression=PARQUET_COMPRESSION_TYPE)


### PR DESCRIPTION
I think a TODO that remains is that, when actually writing the Parquet files, we should directly put the `schema` and `functions` in there.